### PR TITLE
Fix AI review comments

### DIFF
--- a/applications/distributed/ucxx_endoscopy_tool_tracking/cpp/publisher.cpp
+++ b/applications/distributed/ucxx_endoscopy_tool_tracking/cpp/publisher.cpp
@@ -282,7 +282,8 @@ void UcxxEndoscopyPublisherApp::compose() {
       "ucxx_sender_holoviz",
       Arg("tag", 1ul),
       Arg("endpoint") = ucxx_endpoint_holoviz,
-      Arg("blocking") = from_config("publisher.blocking").as<bool>());
+      Arg("blocking") = from_config("publisher.blocking").as<bool>(),
+      Arg("tensor_name") = "render_buffer_output");
 
   // -------------------------------------------------------------------------------------------
   // ---------------------------- Overlay Subscriber -------------------------------------------

--- a/operators/ucxx_send_receive/sender_op/ucxx_sender_op.cpp
+++ b/operators/ucxx_send_receive/sender_op/ucxx_sender_op.cpp
@@ -38,6 +38,11 @@ void UcxxSenderOp::setup(holoscan::OperatorSpec& spec) {
              "If true, do not execute until endpoint is connected. If false (default), drain "
              "inputs and drop sends while disconnected (prevents upstream backpressure).",
              false);
+  spec.param(tensor_name_,
+             "tensor_name",
+             "Tensor name",
+             "Name of the tensor to send, defaults to empty string.",
+             std::string{});
   spec.input<holoscan::gxf::Entity>("in");
 
   bool blocking_value = false;
@@ -138,7 +143,8 @@ void UcxxSenderOp::compute(holoscan::InputContext& input, holoscan::OutputContex
     return;
   }
 
-  auto resolved = holoscan::ops::ucxx::resolveEntityBuffer(in_message);
+  const std::string& tensor_name = tensor_name_.get();
+  auto resolved = holoscan::ops::ucxx::resolveEntityBuffer(in_message, tensor_name.c_str());
   if (!resolved) {
     HOLOSCAN_LOG_ERROR("No sendable buffer found in input message");
     return;

--- a/operators/ucxx_send_receive/sender_op/ucxx_sender_op.hpp
+++ b/operators/ucxx_send_receive/sender_op/ucxx_sender_op.hpp
@@ -42,6 +42,7 @@ class UcxxSenderOp : public holoscan::Operator {
   holoscan::Parameter<bool> blocking_;
   // Cap number of in-flight requests to bound memory retention when the network/receiver stalls.
   holoscan::Parameter<uint64_t> max_in_flight_;
+  holoscan::Parameter<std::string> tensor_name_;  // Name of the tensor to send
 
   struct SendRequest {
     std::shared_ptr<::ucxx::Request> header_request;  // For header

--- a/operators/ucxx_send_receive/serialize_tensor.cpp
+++ b/operators/ucxx_send_receive/serialize_tensor.cpp
@@ -158,7 +158,7 @@ std::optional<BufferDescriptor> resolveEntityBuffer(
   }
 
   // 3. Try nvidia::gxf::VideoBuffer (packed RGB/RGBA, owned by entity)
-  auto maybe_vb = gxf_entity.get<nvidia::gxf::VideoBuffer>();
+  auto maybe_vb = gxf_entity.get<nvidia::gxf::VideoBuffer>(tensor_name);
   if (maybe_vb) {
     auto* vb = maybe_vb.value().get();
     TensorHeader header = buildTensorHeader(*vb);

--- a/operators/ucxx_send_receive/ucxx_endpoint.cpp
+++ b/operators/ucxx_send_receive/ucxx_endpoint.cpp
@@ -244,8 +244,21 @@ void UcxxEndpoint::initialize() {
         }
         ::close(client_fd);
 
-        auto remote_address = ::ucxx::createAddressFromString(remote_address_str);
-        activate_endpoint(worker_->createEndpointFromWorkerAddress(remote_address, true));
+        try {
+          auto remote_address = ::ucxx::createAddressFromString(remote_address_str);
+          activate_endpoint(worker_->createEndpointFromWorkerAddress(remote_address, true));
+        } catch (const std::exception& e) {
+          HOLOSCAN_LOG_ERROR("Failed to activate endpoint for {}:{}: {}",
+                             hostname_.get(),
+                             port_.get(),
+                             e.what());
+          continue;
+        } catch (...) {
+          HOLOSCAN_LOG_ERROR("Failed to activate endpoint for {}:{}: unknown error",
+                             hostname_.get(),
+                             port_.get());
+          continue;
+        }
       }
     });
   } else {
@@ -280,8 +293,21 @@ void UcxxEndpoint::initialize() {
           fmt::format("Failed to receive worker address from {}:{}", hostname_.get(), port_.get()));
     }
 
-    auto remote_address = ::ucxx::createAddressFromString(remote_address_str);
-    activate_endpoint(worker_->createEndpointFromWorkerAddress(remote_address, true));
+    try {
+      auto remote_address = ::ucxx::createAddressFromString(remote_address_str);
+      activate_endpoint(worker_->createEndpointFromWorkerAddress(remote_address, true));
+    } catch (const std::exception& e) {
+      HOLOSCAN_LOG_ERROR("Failed to activate endpoint for {}:{}: {}",
+                         hostname_.get(),
+                         port_.get(),
+                         e.what());
+      throw;
+    } catch (...) {
+      HOLOSCAN_LOG_ERROR("Failed to activate endpoint for {}:{}: unknown error",
+                         hostname_.get(),
+                         port_.get());
+      throw;
+    }
   }
 }
 


### PR DESCRIPTION

Address the following 2 AI review comments

- Add `tensor_name` arg in sender op (defaults to `""`) for more robust name based lookup
- Add error handling in endpoint activation